### PR TITLE
Pulling in error message.

### DIFF
--- a/nest.py
+++ b/nest.py
@@ -29,7 +29,7 @@ except ImportError:
        import simplejson as json
    except ImportError:
        print "No json library available. I recommend installing either python-json"
-       print "or simpejson."
+       print "or simplejson. Python 2.6+ contains json library already."
        sys.exit(-1)
 
 class Nest:


### PR DESCRIPTION
Fixed a typo and added some more detail about how to get the json library working when it fails. (My server is on Centos 5.2 and the python available over yum is 2.4 which did not have a json library built in.)
